### PR TITLE
security(core): fix SQL injection in tile + reverse geocode SQL builders (#9)

### DIFF
--- a/.claude/rules/core-library.md
+++ b/.claude/rules/core-library.md
@@ -12,7 +12,9 @@ This is `@walkthru-earth/geocoding-core`, a framework-agnostic library. Zero UI 
 - `search.ts` - SearchCache<T> (LRU+TTL), jaccardSimilarity(), preNormalize(), array search (sub-ms with optional pre-normalization)
 - `address-parser.ts` - 10 country parsers + GenericParser, POSTCODE_RE, NUMBER_FIRST
 - `types.ts` - AddressRow, CityRow, SuggestRow, ManifestRow, index types
-- `utils.ts` - fmt(), esc(), htmlEsc(), validateCC(), validateH3(), validateBucket(), validateFiniteNumber(), toArr(), step logging
+- `utils.ts` - fmt(), esc(), htmlEsc(), validateCC(), validateH3(), validateBucket(), validateFiniteNumber(), validateSourceExpr(), toArr(), step logging
+- `forward-geocode.ts` - resolveTileSource(), batchTilesSourceExpr(), buildForwardTileQuerySQL(). Keeps all tile source string building + the per-tile SELECT out of the Svelte app
+- `reverse-geocode.ts` - buildReverseQuerySQL(), buildTileLookupSQL(), radiusToBbox(), gridKForRadius(). All builders validate inputs at entry
 
 ## Key patterns
 - All SQL uses HTTPS URLs, never s3://
@@ -21,6 +23,7 @@ This is `@walkthru-earth/geocoding-core`, a framework-agnostic library. Zero UI 
 - `validateH3(h)` asserts `H3_RE = /^[0-9a-f]+$/i` before tile ids are interpolated into URLs or SQL
 - `validateBucket(b)` asserts `/^[0-9a-z_]+$/i` before bucket ids are interpolated into URLs, SQL, or cached table names
 - `validateFiniteNumber(n, label)` guards all numeric SQL parameters (lat, lon, bbox, limit, gridK). Integer-only params also use `Number.isInteger()` with explicit bounds
+- `validateSourceExpr(src)` whitelists the `FROM` position: only cached tile identifiers (`"_tile_XX_..."`) or `read_parquet('https://...parquet')` / `read_parquet([...])` expressions are accepted. Build src strings via `resolveTileSource` / `batchTilesSourceExpr` / `tileSourceExpr`, never concatenate them in app code
 - `htmlEsc()` used in all map popup HTML templates (prevents XSS from address data)
 - Autocomplete never fetches remote data. Only queries what is already cached in WASM memory
 - Country prefetch is progressive: cities first (Phase 1, unlocks UI), then postcodes, then streets. City records also loaded into a JS array for sub-ms search

--- a/.claude/rules/core-library.md
+++ b/.claude/rules/core-library.md
@@ -12,13 +12,15 @@ This is `@walkthru-earth/geocoding-core`, a framework-agnostic library. Zero UI 
 - `search.ts` - SearchCache<T> (LRU+TTL), jaccardSimilarity(), preNormalize(), array search (sub-ms with optional pre-normalization)
 - `address-parser.ts` - 10 country parsers + GenericParser, POSTCODE_RE, NUMBER_FIRST
 - `types.ts` - AddressRow, CityRow, SuggestRow, ManifestRow, index types
-- `utils.ts` - fmt(), esc(), htmlEsc(), validateCC(), toArr(), step logging
+- `utils.ts` - fmt(), esc(), htmlEsc(), validateCC(), validateH3(), validateBucket(), validateFiniteNumber(), toArr(), step logging
 
 ## Key patterns
 - All SQL uses HTTPS URLs, never s3://
 - SQL strings use `esc()` for single-quote escaping (prevent injection)
 - `validateCC(cc)` asserts `/^[A-Z]{2}$/` at every SQL builder entry point (prevents table name injection)
-- Tile IDs validated against `/^[0-9a-f]+$/i` before interpolation into URLs
+- `validateH3(h)` asserts `H3_RE = /^[0-9a-f]+$/i` before tile ids are interpolated into URLs or SQL
+- `validateBucket(b)` asserts `/^[0-9a-z_]+$/i` before bucket ids are interpolated into URLs, SQL, or cached table names
+- `validateFiniteNumber(n, label)` guards all numeric SQL parameters (lat, lon, bbox, limit, gridK). Integer-only params also use `Number.isInteger()` with explicit bounds
 - `htmlEsc()` used in all map popup HTML templates (prevents XSS from address data)
 - Autocomplete never fetches remote data. Only queries what is already cached in WASM memory
 - Country prefetch is progressive: cities first (Phase 1, unlocks UI), then postcodes, then streets. City records also loaded into a JS array for sub-ms search

--- a/.claude/rules/playground-app.md
+++ b/.claude/rules/playground-app.md
@@ -20,7 +20,7 @@ Svelte 5 app with reactive variables ($state, $derived, $effect). Uses Tailwind 
 - `StepLog.svelte` - Execution step log for transparency
 
 ## Conventions
-- All geocoding logic lives in core, not in Svelte components
+- All geocoding logic lives in core, not in Svelte components. Specifically, tile source strings (cached identifiers or `read_parquet(...)` expressions) are built via `resolveTileSource` / `batchTilesSourceExpr`, and the per-tile SELECT is built via `buildForwardTileQuerySQL` / `buildReverseQuerySQL`. Pages never concatenate SQL or parquet URLs inline
 - The app injects query functions into the autocomplete engine via `AutocompleteQueryFns`
 - Debounced autocomplete (150ms)
 - Async search flows use generation counters (`searchGen`, `autoGen`) + `cancelPendingQuery()` to cancel in-flight DuckDB queries before new searches

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,8 @@ jobs:
         with:
           working-directory: packages/core
           vite-config-path: vitest.config.ts
+          json-summary-path: ../../test-output/unit/coverage/coverage-summary.json
+          json-final-path: ../../test-output/unit/coverage/coverage-final.json
 
   e2e-tests:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,8 @@ See `_study/` for detailed architecture docs, data profiles, and issue history.
 - Country codes MUST be validated with `validateCC(cc)` at every SQL builder entry point. Never interpolate `cc` into table names or URLs without it
 - Tile IDs MUST be validated with `validateH3(h)` (regex `H3_RE = /^[0-9a-f]+$/i`) before interpolation into parquet URLs or SQL
 - Tile bucket ids MUST be validated with `validateBucket(b)` (alphanumerics + underscore) before interpolation into parquet URLs, SQL, or cached table names
-- Numeric parameters (lat, lon, bbox, limit, gridK) MUST be validated with `validateFiniteNumber()` / `Number.isInteger()` at every SQL builder entry point. Never interpolate `number` typed values raw, runtime JSON can smuggle strings or `NaN`
+- Numeric parameters (lat, lon, bbox, limit, gridK) MUST be validated with `validateFiniteNumber()` / `Number.isInteger()` at every SQL builder entry point. Never interpolate `number`-typed values raw, runtime JSON can smuggle strings or `NaN`
+- `FROM ${src}` expressions MUST be validated with `validateSourceExpr()`. Tile source strings are built inside core (`resolveTileSource`, `batchTilesSourceExpr`, `tileSourceExpr`) and callers should never concatenate `read_parquet(...)` or identifiers in app code
 - Array values from query results (like `cityTiles`) MUST be escaped individually: `tiles.map(t => esc(t))`, not joined raw. Arrays of tile ids should go through `validateH3()` instead of `esc()`
 
 ### HTML in map popups

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,8 +85,10 @@ See `_study/` for detailed architecture docs, data profiles, and issue history.
 ### SQL interpolation
 - All user-facing string values MUST go through `esc()` before interpolation into SQL
 - Country codes MUST be validated with `validateCC(cc)` at every SQL builder entry point. Never interpolate `cc` into table names or URLs without it
-- Tile IDs MUST be validated against `/^[0-9a-f]+$/i` before interpolation into parquet URLs
-- Array values from query results (like `cityTiles`) MUST be escaped individually: `tiles.map(t => esc(t))`, not joined raw
+- Tile IDs MUST be validated with `validateH3(h)` (regex `H3_RE = /^[0-9a-f]+$/i`) before interpolation into parquet URLs or SQL
+- Tile bucket ids MUST be validated with `validateBucket(b)` (alphanumerics + underscore) before interpolation into parquet URLs, SQL, or cached table names
+- Numeric parameters (lat, lon, bbox, limit, gridK) MUST be validated with `validateFiniteNumber()` / `Number.isInteger()` at every SQL builder entry point. Never interpolate `number` typed values raw, runtime JSON can smuggle strings or `NaN`
+- Array values from query results (like `cityTiles`) MUST be escaped individually: `tiles.map(t => esc(t))`, not joined raw. Arrays of tile ids should go through `validateH3()` instead of `esc()`
 
 ### HTML in map popups
 - All address data inserted into popup HTML MUST use `htmlEsc()`. Address strings from Overture can contain `&`, `<`, `>`, or quotes

--- a/apps/playground/src/pages/GeocodePage.svelte
+++ b/apps/playground/src/pages/GeocodePage.svelte
@@ -1,13 +1,15 @@
 <script lang="ts">
   import {
-    queryObjects, queryObjectsWithRetry, tilePath, prefetchCountry, isCountryCached, onCacheLog,
-    getTileSource, isTileCached, expandTilesToBucketGroups, tileSourceExpr,
+    queryObjects, queryObjectsWithRetry, prefetchCountry, isCountryCached, onCacheLog,
+    isTileCached, expandTilesToBucketGroups,
     cancelPendingQuery, getCountryTable,
     SearchCache, searchCities as searchCitiesJS,
     getParser, stripJPCoordZone,
     esc, toArr, ms, addStep, updateLastStep, htmlEsc,
     suggest, classifyInput, resolveTiles, rankSuggestions,
     buildPostcodeSQL, buildStreetSQL, buildPostcodeNarrowSQL, buildStreetNarrowSQL, buildNumberIndexSQL,
+    // Forward geocode (core)
+    resolveTileSource, batchTilesSourceExpr, buildForwardTileQuerySQL,
     // Reverse geocode (core)
     radiusToBbox, gridKForRadius, buildTileLookupSQL, buildReverseQuerySQL,
   } from '@walkthru-earth/geocoding-core'
@@ -584,26 +586,14 @@
     try {
       if (hasSpecificFilters && tileGroups.length > 1) {
         log(`Mode    Batch query with Parquet filter pushdown`, undefined)
-        const allUrls: string[] = []
-        for (const { h3Res4, buckets: tileBuckets } of tileGroups) {
-          for (const b of tileBuckets) {
-            allUrls.push(tilePath(cc, h3Res4, b))
-          }
-        }
-        const src = `read_parquet([${allUrls.map(u => `'${u}'`).join(',')}])`
+        const src = batchTilesSourceExpr(cc, tileGroups)
+        const fileCount = tileGroups.reduce((n, t) => n + t.buckets.length, 0)
         const t0 = performance.now()
-        log(`        Batch across ${allUrls.length} file(s)...`, 'loading')
+        log(`        Batch across ${fileCount} file(s)...`, 'loading')
         try {
-          results = await queryObjectsWithRetry<AddressRow>(`
-            SELECT full_address, street, number, city, region, postcode,
-                   ST_Y(geometry) AS lat, ST_X(geometry) AS lon,
-                   h3_h3_to_string(h3_index) AS h3_index
-            FROM ${src}
-            WHERE ${where}
-            LIMIT ${limit}
-          `)
+          results = await queryObjectsWithRetry<AddressRow>(buildForwardTileQuerySQL(src, where, limit))
           if (gen !== searchGen) return
-          updateLast(`        Batch across ${allUrls.length} file(s), ${results.length} match(es) (${ms(t0)})`, 'done')
+          updateLast(`        Batch across ${fileCount} file(s), ${results.length} match(es) (${ms(t0)})`, 'done')
           searching = false
           updateMapMarkers(true)
         } catch (batchErr: any) {
@@ -640,26 +630,11 @@
 
           let tileResults: AddressRow[] = []
           try {
-            let src: string
-            let useRetry = false
-            if (tileBuckets.length === 1 && isTileCached(cc, h3Res4, tileBuckets[0])) {
-              src = await getTileSource(cc, h3Res4, tileBuckets[0])
-            } else if (hasSpecificFilters || tileBuckets.length > 1) {
-              src = tileSourceExpr(cc, h3Res4, tileBuckets)
-              useRetry = true
-            } else {
-              src = await getTileSource(cc, h3Res4, tileBuckets[0])
-            }
-
+            const multiBucket = tileBuckets.length > 1
+            const useRetry = multiBucket || hasSpecificFilters
+            const src = await resolveTileSource(cc, h3Res4, tileBuckets, { preferCache: !useRetry })
             const queryFn = useRetry ? queryObjectsWithRetry : queryObjects
-            tileResults = await queryFn<AddressRow>(`
-              SELECT full_address, street, number, city, region, postcode,
-                     ST_Y(geometry) AS lat, ST_X(geometry) AS lon,
-                     h3_h3_to_string(h3_index) AS h3_index
-              FROM ${src}
-              WHERE ${where}
-              LIMIT ${remaining}
-            `)
+            tileResults = await queryFn<AddressRow>(buildForwardTileQuerySQL(src, where, remaining))
           } catch (tileErr: any) {
             console.warn(`[geocode] Tile ${h3Res4} failed:`, tileErr.message)
             updateLast(`        ${label}, failed (${ms(t0)})`, 'error')
@@ -768,10 +743,7 @@
 
         let tileAddresses: AddressRow[] = []
         try {
-          const src = cached
-            ? await getTileSource(country, h3_res4, bucket)
-            : `read_parquet('${tilePath(country, h3_res4, bucket)}')`
-
+          const src = await resolveTileSource(country, h3_res4, [bucket], { preferCache: cached })
           tileAddresses = await queryObjects<AddressRow>(buildReverseQuerySQL(src, country, lat, lon, bbox, resultLimit))
         } catch (err: any) {
           console.warn(`[reverse] Bucket ${label} failed:`, err.message)

--- a/packages/core/src/__tests__/forward-geocode.test.ts
+++ b/packages/core/src/__tests__/forward-geocode.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { batchTilesSourceExpr, buildForwardTileQuerySQL } from '../forward-geocode'
+
+describe('batchTilesSourceExpr', () => {
+  it('builds a read_parquet([...]) for valid tiles', () => {
+    const src = batchTilesSourceExpr('NL', [
+      { h3Res4: '841f8bfffffffff', buckets: ['_'] },
+      { h3Res4: '841f8b7ffffffff', buckets: ['01', '02'] },
+    ])
+    expect(src.startsWith('read_parquet([')).toBe(true)
+    expect(src.split(',').length).toBe(3)
+    expect(src.includes('country=NL')).toBe(true)
+  })
+  it('rejects invalid country', () => {
+    expect(() => batchTilesSourceExpr("NL'--", [{ h3Res4: 'abc', buckets: ['_'] }])).toThrow('Invalid country code')
+  })
+  it('rejects invalid h3 id', () => {
+    expect(() => batchTilesSourceExpr('NL', [{ h3Res4: "abc'; DROP--", buckets: ['_'] }])).toThrow('Invalid h3 id')
+  })
+  it('rejects empty tile list', () => {
+    expect(() => batchTilesSourceExpr('NL', [])).toThrow('no tiles')
+  })
+})
+
+describe('buildForwardTileQuerySQL', () => {
+  const validSrc = "read_parquet('https://s3.example.com/tile.parquet')"
+
+  it('builds SQL for a valid src + where + limit', () => {
+    const sql = buildForwardTileQuerySQL(validSrc, "street = 'Main'", 100)
+    expect(sql).toContain('FROM read_parquet')
+    expect(sql).toContain("WHERE street = 'Main'")
+    expect(sql).toContain('LIMIT 100')
+  })
+  it('rejects unsafe src', () => {
+    expect(() => buildForwardTileQuerySQL('tbl', 'true', 10)).toThrow('Invalid src')
+  })
+  it('rejects non-integer limit', () => {
+    expect(() => buildForwardTileQuerySQL(validSrc, 'true', 0)).toThrow('Invalid limit')
+    expect(() => buildForwardTileQuerySQL(validSrc, 'true', 1.5)).toThrow('Invalid limit')
+    expect(() => buildForwardTileQuerySQL(validSrc, 'true', 999999)).toThrow('Invalid limit')
+  })
+})

--- a/packages/core/src/__tests__/reverse-geocode.test.ts
+++ b/packages/core/src/__tests__/reverse-geocode.test.ts
@@ -4,26 +4,40 @@ import { buildReverseQuerySQL, buildTileLookupSQL, radiusToBbox } from '../rever
 const bbox = { minLat: 52, maxLat: 53, minLon: 4, maxLon: 5 }
 
 describe('buildReverseQuerySQL', () => {
-  it('builds SQL for valid inputs', () => {
-    const sql = buildReverseQuerySQL('tbl', 'NL', 52.3, 4.9, bbox, 50)
+  it('builds SQL for a cached tile identifier', () => {
+    const sql = buildReverseQuerySQL('"_tile_NL_841f8b_01"', 'NL', 52.3, 4.9, bbox, 50)
     expect(sql).toContain("'NL' AS country")
     expect(sql).toContain('LIMIT 50')
   })
+  it('builds SQL for a read_parquet source', () => {
+    const src = "read_parquet('https://example.com/tile.parquet')"
+    expect(() => buildReverseQuerySQL(src, 'NL', 52, 4, bbox, 50)).not.toThrow()
+  })
+  it('rejects raw table names not in the whitelist', () => {
+    expect(() => buildReverseQuerySQL('tbl', 'NL', 52, 4, bbox, 50)).toThrow('Invalid src')
+  })
+  it('rejects src with injected SQL', () => {
+    expect(() => buildReverseQuerySQL('tbl; DROP TABLE x', 'NL', 52, 4, bbox, 50)).toThrow('Invalid src')
+  })
   it('rejects invalid country', () => {
-    expect(() => buildReverseQuerySQL('tbl', "NL'; DROP--", 52, 4, bbox, 50)).toThrow('Invalid country code')
+    expect(() => buildReverseQuerySQL('"_tile_NL_841f8b_01"', "NL'; DROP--", 52, 4, bbox, 50)).toThrow(
+      'Invalid country code',
+    )
   })
   it('rejects non-finite lat/lon', () => {
-    expect(() => buildReverseQuerySQL('tbl', 'NL', Number.NaN, 4, bbox, 50)).toThrow('Invalid lat')
-    expect(() => buildReverseQuerySQL('tbl', 'NL', 52, Number.POSITIVE_INFINITY, bbox, 50)).toThrow('Invalid lon')
+    expect(() => buildReverseQuerySQL('"_tile_NL_841f8b_01"', 'NL', Number.NaN, 4, bbox, 50)).toThrow('Invalid lat')
+    expect(() => buildReverseQuerySQL('"_tile_NL_841f8b_01"', 'NL', 52, Number.POSITIVE_INFINITY, bbox, 50)).toThrow(
+      'Invalid lon',
+    )
   })
   it('rejects invalid bbox', () => {
     const bad = { ...bbox, minLat: Number.NaN }
-    expect(() => buildReverseQuerySQL('tbl', 'NL', 52, 4, bad, 50)).toThrow('Invalid bbox.minLat')
+    expect(() => buildReverseQuerySQL('"_tile_NL_841f8b_01"', 'NL', 52, 4, bad, 50)).toThrow('Invalid bbox.minLat')
   })
   it('rejects invalid limit', () => {
-    expect(() => buildReverseQuerySQL('tbl', 'NL', 52, 4, bbox, 0)).toThrow('Invalid limit')
-    expect(() => buildReverseQuerySQL('tbl', 'NL', 52, 4, bbox, 1.5)).toThrow('Invalid limit')
-    expect(() => buildReverseQuerySQL('tbl', 'NL', 52, 4, bbox, 99999)).toThrow('Invalid limit')
+    expect(() => buildReverseQuerySQL('"_tile_NL_841f8b_01"', 'NL', 52, 4, bbox, 0)).toThrow('Invalid limit')
+    expect(() => buildReverseQuerySQL('"_tile_NL_841f8b_01"', 'NL', 52, 4, bbox, 1.5)).toThrow('Invalid limit')
+    expect(() => buildReverseQuerySQL('"_tile_NL_841f8b_01"', 'NL', 52, 4, bbox, 99999)).toThrow('Invalid limit')
   })
 })
 

--- a/packages/core/src/__tests__/reverse-geocode.test.ts
+++ b/packages/core/src/__tests__/reverse-geocode.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { buildReverseQuerySQL, buildTileLookupSQL, radiusToBbox } from '../reverse-geocode'
+
+const bbox = { minLat: 52, maxLat: 53, minLon: 4, maxLon: 5 }
+
+describe('buildReverseQuerySQL', () => {
+  it('builds SQL for valid inputs', () => {
+    const sql = buildReverseQuerySQL('tbl', 'NL', 52.3, 4.9, bbox, 50)
+    expect(sql).toContain("'NL' AS country")
+    expect(sql).toContain('LIMIT 50')
+  })
+  it('rejects invalid country', () => {
+    expect(() => buildReverseQuerySQL('tbl', "NL'; DROP--", 52, 4, bbox, 50)).toThrow('Invalid country code')
+  })
+  it('rejects non-finite lat/lon', () => {
+    expect(() => buildReverseQuerySQL('tbl', 'NL', Number.NaN, 4, bbox, 50)).toThrow('Invalid lat')
+    expect(() => buildReverseQuerySQL('tbl', 'NL', 52, Number.POSITIVE_INFINITY, bbox, 50)).toThrow('Invalid lon')
+  })
+  it('rejects invalid bbox', () => {
+    const bad = { ...bbox, minLat: Number.NaN }
+    expect(() => buildReverseQuerySQL('tbl', 'NL', 52, 4, bad, 50)).toThrow('Invalid bbox.minLat')
+  })
+  it('rejects invalid limit', () => {
+    expect(() => buildReverseQuerySQL('tbl', 'NL', 52, 4, bbox, 0)).toThrow('Invalid limit')
+    expect(() => buildReverseQuerySQL('tbl', 'NL', 52, 4, bbox, 1.5)).toThrow('Invalid limit')
+    expect(() => buildReverseQuerySQL('tbl', 'NL', 52, 4, bbox, 99999)).toThrow('Invalid limit')
+  })
+})
+
+describe('buildTileLookupSQL', () => {
+  it('builds SQL for gridK=0', () => {
+    const sql = buildTileLookupSQL(52.3, 4.9, 0)
+    expect(sql).toContain('h3_latlng_to_cell(52.3, 4.9')
+  })
+  it('builds SQL for gridK>0', () => {
+    const sql = buildTileLookupSQL(52.3, 4.9, 2)
+    expect(sql).toContain('h3_grid_disk')
+  })
+  it('rejects non-finite coords', () => {
+    expect(() => buildTileLookupSQL(Number.NaN, 4, 0)).toThrow('Invalid lat')
+  })
+  it('rejects invalid gridK', () => {
+    expect(() => buildTileLookupSQL(52, 4, -1)).toThrow('Invalid gridK')
+    expect(() => buildTileLookupSQL(52, 4, 1.5)).toThrow('Invalid gridK')
+    expect(() => buildTileLookupSQL(52, 4, 999)).toThrow('Invalid gridK')
+  })
+})
+
+describe('radiusToBbox', () => {
+  it('produces a bbox enclosing the point', () => {
+    const b = radiusToBbox(52.3, 4.9, 5000)
+    expect(b.minLat).toBeLessThan(52.3)
+    expect(b.maxLat).toBeGreaterThan(52.3)
+    expect(b.minLon).toBeLessThan(4.9)
+    expect(b.maxLon).toBeGreaterThan(4.9)
+  })
+})

--- a/packages/core/src/__tests__/utils.test.ts
+++ b/packages/core/src/__tests__/utils.test.ts
@@ -1,5 +1,17 @@
 import { describe, expect, it } from 'vitest'
-import { addStep, esc, fmt, fmtFull, formatSize, toArr, updateLastStep, validateCC } from '../utils'
+import {
+  addStep,
+  esc,
+  fmt,
+  fmtFull,
+  formatSize,
+  toArr,
+  updateLastStep,
+  validateBucket,
+  validateCC,
+  validateFiniteNumber,
+  validateH3,
+} from '../utils'
 
 describe('fmt', () => {
   it.each([
@@ -75,6 +87,43 @@ describe('validateCC', () => {
 
   it('rejects empty string', () => {
     expect(() => validateCC('')).toThrow('Invalid country code')
+  })
+})
+
+describe('validateH3', () => {
+  it('accepts hex digits', () => {
+    expect(() => validateH3('841f8bfffffffff')).not.toThrow()
+    expect(() => validateH3('ABCDEF0123')).not.toThrow()
+  })
+  it('rejects injection attempts', () => {
+    expect(() => validateH3("'; DROP TABLE x; --")).toThrow('Invalid h3 id')
+    expect(() => validateH3('abc xyz')).toThrow('Invalid h3 id')
+    expect(() => validateH3('')).toThrow('Invalid h3 id')
+  })
+})
+
+describe('validateBucket', () => {
+  it('accepts alphanumerics and underscore', () => {
+    expect(() => validateBucket('_')).not.toThrow()
+    expect(() => validateBucket('01')).not.toThrow()
+    expect(() => validateBucket('bucket_1')).not.toThrow()
+  })
+  it('rejects injection attempts', () => {
+    expect(() => validateBucket("'; DROP--")).toThrow('Invalid bucket')
+    expect(() => validateBucket('a/b')).toThrow('Invalid bucket')
+    expect(() => validateBucket('')).toThrow('Invalid bucket')
+  })
+})
+
+describe('validateFiniteNumber', () => {
+  it('accepts finite numbers', () => {
+    expect(() => validateFiniteNumber(0, 'x')).not.toThrow()
+    expect(() => validateFiniteNumber(-12.5, 'x')).not.toThrow()
+  })
+  it('rejects NaN/Infinity/non-numbers', () => {
+    expect(() => validateFiniteNumber(Number.NaN, 'lat')).toThrow('Invalid lat')
+    expect(() => validateFiniteNumber(Number.POSITIVE_INFINITY, 'lat')).toThrow('Invalid lat')
+    expect(() => validateFiniteNumber('1' as unknown as number, 'lat')).toThrow('Invalid lat')
   })
 })
 

--- a/packages/core/src/__tests__/utils.test.ts
+++ b/packages/core/src/__tests__/utils.test.ts
@@ -11,6 +11,7 @@ import {
   validateCC,
   validateFiniteNumber,
   validateH3,
+  validateSourceExpr,
 } from '../utils'
 
 describe('fmt', () => {
@@ -124,6 +125,33 @@ describe('validateFiniteNumber', () => {
     expect(() => validateFiniteNumber(Number.NaN, 'lat')).toThrow('Invalid lat')
     expect(() => validateFiniteNumber(Number.POSITIVE_INFINITY, 'lat')).toThrow('Invalid lat')
     expect(() => validateFiniteNumber('1' as unknown as number, 'lat')).toThrow('Invalid lat')
+  })
+})
+
+describe('validateSourceExpr', () => {
+  it('accepts a cached tile identifier', () => {
+    expect(() => validateSourceExpr('"_tile_NL_841f8b_01"')).not.toThrow()
+    expect(() => validateSourceExpr('"_tile_US_8a2a1072b59ffff_mega_02"')).not.toThrow()
+  })
+  it('accepts a single read_parquet HTTPS url', () => {
+    expect(() => validateSourceExpr("read_parquet('https://s3.example.com/tile.parquet')")).not.toThrow()
+  })
+  it('accepts a read_parquet list of HTTPS urls', () => {
+    expect(() =>
+      validateSourceExpr("read_parquet(['https://s3.example.com/a.parquet','https://s3.example.com/b.parquet'])"),
+    ).not.toThrow()
+  })
+  it('rejects raw identifiers', () => {
+    expect(() => validateSourceExpr('tbl')).toThrow('Invalid src')
+    expect(() => validateSourceExpr('_tile_NL_ab_01')).toThrow('Invalid src')
+  })
+  it('rejects non-HTTPS urls', () => {
+    expect(() => validateSourceExpr("read_parquet('http://evil.com/x.parquet')")).toThrow('Invalid src')
+    expect(() => validateSourceExpr("read_parquet('s3://bucket/x.parquet')")).toThrow('Invalid src')
+  })
+  it('rejects injection attempts', () => {
+    expect(() => validateSourceExpr('tbl; DROP TABLE users; --')).toThrow('Invalid src')
+    expect(() => validateSourceExpr("read_parquet('https://x.parquet') UNION SELECT 1")).toThrow('Invalid src')
   })
 })
 

--- a/packages/core/src/duckdb.ts
+++ b/packages/core/src/duckdb.ts
@@ -1,4 +1,5 @@
 import * as duckdb from '@duckdb/duckdb-wasm'
+import { validateBucket, validateCC, validateH3 } from './utils'
 
 // Public HTTPS URL for all data access. S3 protocol is slower in WASM
 // and glob support is experimental. Pipeline ensures one file per partition.
@@ -199,6 +200,9 @@ export function indexPath(type: string, cc: string): string {
  * Normal tiles have bucket='_', mega-tiles have bucket='01','02',...
  */
 export function tilePath(country: string, h3Res4: string, bucket: string): string {
+  validateCC(country)
+  validateH3(h3Res4)
+  validateBucket(bucket)
   return `${DATA_BASE}/geocoder/country=${country}/h3_res4=${h3Res4}/bucket=${bucket}/data_0.parquet`
 }
 
@@ -431,6 +435,9 @@ async function evictTiles(neededAddr: number): Promise<void> {
  * v4: tiles are identified by (country, h3Res4, bucket).
  */
 export async function getTileSource(country: string, h3Res4: string, bucket: string): Promise<string> {
+  validateCC(country)
+  validateH3(h3Res4)
+  validateBucket(bucket)
   const key = tileCacheKey(country, h3Res4, bucket)
   const cached = tileCache.get(key)
   if (cached) {
@@ -474,6 +481,9 @@ export async function getTileSource(country: string, h3Res4: string, bucket: str
 
 /** Check if a tile bucket is already cached in memory. */
 export function isTileCached(country: string, h3Res4: string, bucket: string): boolean {
+  validateCC(country)
+  validateH3(h3Res4)
+  validateBucket(bucket)
   return tileCache.has(tileCacheKey(country, h3Res4, bucket))
 }
 
@@ -491,7 +501,9 @@ export async function expandTilesToBucketGroups(
   h3Res4s: string[],
 ): Promise<{ h3Res4: string; buckets: string[]; totalAddresses: number }[]> {
   if (h3Res4s.length === 0) return []
-  const tileList = h3Res4s.map((t) => `'${t.replace(/'/g, "''")}'`).join(',')
+  validateCC(country)
+  for (const t of h3Res4s) validateH3(t)
+  const tileList = h3Res4s.map((t) => `'${t}'`).join(',')
   return queryObjects<{ h3Res4: string; buckets: string[]; totalAddresses: number }>(`
     SELECT h3_res4 AS "h3Res4",
            list(bucket ORDER BY bucket) AS buckets,

--- a/packages/core/src/forward-geocode.ts
+++ b/packages/core/src/forward-geocode.ts
@@ -1,0 +1,76 @@
+// Forward geocode SQL builders.
+// Framework-agnostic, no UI dependencies.
+
+import { getTileSource, isTileCached, tilePath, tileSourceExpr } from './duckdb'
+import { validateCC, validateH3, validateSourceExpr } from './utils'
+
+/**
+ * Resolve a safe `FROM` source expression for a single h3_res4 tile.
+ *
+ * The returned string is always either a cached tile identifier
+ * (`"_tile_XX_..."`) or a `read_parquet('...')` / `read_parquet([...])`
+ * expression with validated HTTPS URLs. Callers can pass it directly
+ * into `FROM ${src}` after a `validateSourceExpr()` check.
+ *
+ * Keeps all tile source string construction inside core so the Svelte
+ * playground never builds raw SQL or parquet URL expressions.
+ */
+export async function resolveTileSource(
+  country: string,
+  h3Res4: string,
+  buckets: string[],
+  opts: { preferCache?: boolean } = {},
+): Promise<string> {
+  validateCC(country)
+  validateH3(h3Res4)
+  if (buckets.length === 0) throw new Error('resolveTileSource: buckets is empty')
+  const preferCache = opts.preferCache ?? true
+  // Multi-bucket tiles always use a direct parquet read so DuckDB can apply
+  // per-file filter pushdown across all buckets in one query.
+  if (buckets.length > 1) return tileSourceExpr(country, h3Res4, buckets)
+  // Single-bucket tile: prefer the in-memory cache unless the caller opts out
+  // (e.g. when pushdown on the parquet file beats a cached scan).
+  if (preferCache) return getTileSource(country, h3Res4, buckets[0])
+  if (isTileCached(country, h3Res4, buckets[0])) {
+    return getTileSource(country, h3Res4, buckets[0])
+  }
+  return tileSourceExpr(country, h3Res4, buckets)
+}
+
+/**
+ * Build a `read_parquet([...])` expression that spans every bucket of
+ * several h3_res4 tiles. Used for the batch forward-geocode path where
+ * DuckDB applies filter pushdown across all parquet files in one query.
+ */
+export function batchTilesSourceExpr(country: string, tiles: { h3Res4: string; buckets: string[] }[]): string {
+  validateCC(country)
+  if (tiles.length === 0) throw new Error('batchTilesSourceExpr: no tiles')
+  const urls: string[] = []
+  for (const { h3Res4, buckets } of tiles) {
+    validateH3(h3Res4)
+    for (const b of buckets) urls.push(`'${tilePath(country, h3Res4, b)}'`)
+  }
+  return `read_parquet([${urls.join(',')}])`
+}
+
+/**
+ * Build the SELECT used by the forward geocode per-tile query. Validates
+ * the `src` expression against the safe-source whitelist and bounds the
+ * `limit` to reject non-integers and unreasonable values.
+ *
+ * `where` is the output of a parser's `buildWhereClause(parsed)` and is
+ * trusted to contain properly escaped values (the parsers use `esc()`).
+ */
+export function buildForwardTileQuerySQL(src: string, where: string, limit: number): string {
+  validateSourceExpr(src)
+  if (!Number.isInteger(limit) || limit <= 0 || limit > 100000) {
+    throw new Error(`Invalid limit: ${limit}`)
+  }
+  return `
+    SELECT full_address, street, number, city, region, postcode,
+           ST_Y(geometry) AS lat, ST_X(geometry) AS lon,
+           h3_h3_to_string(h3_index) AS h3_index
+    FROM ${src}
+    WHERE ${where}
+    LIMIT ${limit}`
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -47,6 +47,12 @@ export {
   tileSourceExpr,
   toggleExplain,
 } from './duckdb'
+// ── Forward geocode ─────────────────────────────────────────
+export {
+  batchTilesSourceExpr,
+  buildForwardTileQuerySQL,
+  resolveTileSource,
+} from './forward-geocode'
 export { stripJPCoordZone } from './parsers/jp'
 // ── Reverse geocode ─────────────────────────────────────────
 export type { Bbox, TileBucketRow } from './reverse-geocode'

--- a/packages/core/src/reverse-geocode.ts
+++ b/packages/core/src/reverse-geocode.ts
@@ -1,6 +1,8 @@
 // Reverse geocode SQL builders and utilities.
 // Framework-agnostic, no UI dependencies.
 
+import { validateCC, validateFiniteNumber } from './utils'
+
 export interface Bbox {
   minLon: number
   maxLon: number
@@ -38,6 +40,9 @@ export interface TileBucketRow {
  * Uses H3 grid_disk for large radii to cover adjacent tiles.
  */
 export function buildTileLookupSQL(lat: number, lon: number, gridK: number): string {
+  validateFiniteNumber(lat, 'lat')
+  validateFiniteNumber(lon, 'lon')
+  if (!Number.isInteger(gridK) || gridK < 0 || gridK > 10) throw new Error(`Invalid gridK: ${gridK}`)
   if (gridK > 0) {
     return `
       WITH disk AS (
@@ -78,6 +83,14 @@ export function buildReverseQuerySQL(
   bbox: Bbox,
   limit: number,
 ): string {
+  validateCC(country)
+  validateFiniteNumber(lat, 'lat')
+  validateFiniteNumber(lon, 'lon')
+  validateFiniteNumber(bbox.minLat, 'bbox.minLat')
+  validateFiniteNumber(bbox.maxLat, 'bbox.maxLat')
+  validateFiniteNumber(bbox.minLon, 'bbox.minLon')
+  validateFiniteNumber(bbox.maxLon, 'bbox.maxLon')
+  if (!Number.isInteger(limit) || limit <= 0 || limit > 10000) throw new Error(`Invalid limit: ${limit}`)
   return `
     SELECT
       full_address, street, number, city, region, postcode,

--- a/packages/core/src/reverse-geocode.ts
+++ b/packages/core/src/reverse-geocode.ts
@@ -1,7 +1,7 @@
 // Reverse geocode SQL builders and utilities.
 // Framework-agnostic, no UI dependencies.
 
-import { validateCC, validateFiniteNumber } from './utils'
+import { validateCC, validateFiniteNumber, validateSourceExpr } from './utils'
 
 export interface Bbox {
   minLon: number
@@ -83,6 +83,7 @@ export function buildReverseQuerySQL(
   bbox: Bbox,
   limit: number,
 ): string {
+  validateSourceExpr(src)
   validateCC(country)
   validateFiniteNumber(lat, 'lat')
   validateFiniteNumber(lon, 'lon')

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -43,10 +43,27 @@ export function htmlEsc(s: string): string {
 }
 
 const CC_RE = /^[A-Z]{2}$/
+export const H3_RE = /^[0-9a-f]+$/i
+const BUCKET_RE = /^[0-9a-z_]+$/i
 
 /** Validate a 2-letter uppercase country code. Throws on invalid input. */
 export function validateCC(cc: string): void {
   if (!CC_RE.test(cc)) throw new Error(`Invalid country code: ${cc}`)
+}
+
+/** Validate an H3 tile id (hex digits only). Throws on invalid input. */
+export function validateH3(h: string): void {
+  if (typeof h !== 'string' || !H3_RE.test(h)) throw new Error(`Invalid h3 id: ${h}`)
+}
+
+/** Validate a tile bucket id (alphanumerics + underscore). Throws on invalid input. */
+export function validateBucket(b: string): void {
+  if (typeof b !== 'string' || !BUCKET_RE.test(b)) throw new Error(`Invalid bucket: ${b}`)
+}
+
+/** Validate a finite number (not NaN/Infinity). Throws on invalid input. */
+export function validateFiniteNumber(n: number, label: string): void {
+  if (typeof n !== 'number' || !Number.isFinite(n)) throw new Error(`Invalid ${label}: ${n}`)
 }
 
 // ── Data conversion ─────────────────────────────────────────

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -66,6 +66,27 @@ export function validateFiniteNumber(n: number, label: string): void {
   if (typeof n !== 'number' || !Number.isFinite(n)) throw new Error(`Invalid ${label}: ${n}`)
 }
 
+// Whitelist of allowed `FROM` source expressions. Matches one of:
+// 1. A quoted tile cache identifier, `"_tile_XX_<hex>_<bucket>"`, produced by
+//    `tileCacheTableName` after country/h3/bucket are validated.
+// 2. `read_parquet('https://...parquet')` with a single HTTPS tile URL.
+// 3. `read_parquet(['https://...parquet',...])` with one or more HTTPS tile URLs.
+// Anything else is rejected so callers cannot smuggle arbitrary SQL into a
+// `FROM ${src}` interpolation point.
+const SAFE_TILE_IDENT_RE = /^"_tile_[A-Z]{2}_[a-f0-9]+_[a-z0-9_]+"$/
+const SAFE_PARQUET_URL = "'https://[A-Za-z0-9._~:/?#@!$&+=%-]+\\.parquet'"
+const SAFE_PARQUET_SINGLE_RE = new RegExp(`^read_parquet\\(${SAFE_PARQUET_URL}\\)$`)
+const SAFE_PARQUET_LIST_RE = new RegExp(`^read_parquet\\(\\[${SAFE_PARQUET_URL}(?:,${SAFE_PARQUET_URL})*\\]\\)$`)
+
+/** Validate a SQL `FROM` source expression against the tile source whitelist. */
+export function validateSourceExpr(src: string): void {
+  if (typeof src !== 'string') throw new Error(`Invalid src: ${src}`)
+  if (SAFE_TILE_IDENT_RE.test(src)) return
+  if (SAFE_PARQUET_SINGLE_RE.test(src)) return
+  if (SAFE_PARQUET_LIST_RE.test(src)) return
+  throw new Error(`Invalid src: ${src}`)
+}
+
 // ── Data conversion ─────────────────────────────────────────
 
 /** Normalize Arrow/DuckDB array values to plain JS string arrays */

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     },
     coverage: {
       provider: 'v8',
+      reporter: ['text', 'json', 'json-summary', 'html'],
       reportsDirectory: '../../test-output/unit/coverage',
       include: ['src/**/*.ts'],
       exclude: ['src/duckdb.ts', 'src/index.ts', 'src/__tests__/**'],


### PR DESCRIPTION
## Summary

Fixes the three SQL injection findings reported in #9 by validating every interpolated value at the entry of each SQL builder.

- **`getTileSource`** (`duckdb.ts`): `country`, `h3Res4`, and `bucket` now go through `validateCC` / `validateH3` / `validateBucket` before the `_tile_index` lookup and the `CREATE OR REPLACE TABLE` statement.
- **`expandTilesToBucketGroups`** (`duckdb.ts`): `country` validated, and every h3Res4 in the array validated per-element instead of only quote-doubling.
- **`buildReverseQuerySQL`** / **`buildTileLookupSQL`** (`reverse-geocode.ts`): `country` validated, `lat` / `lon` / `bbox` fields validated via `validateFiniteNumber`, `limit` and `gridK` validated as integers with explicit bounds.
- **`tilePath`** / **`isTileCached`**: same validators at entry, since they feed `read_parquet('...')` and the tile cache key.

New helpers `validateH3`, `validateBucket`, `validateFiniteNumber`, and exported `H3_RE` live in `packages/core/src/utils.ts` next to `validateCC`.

## Test plan

- [x] `pnpm test` — 411 passing (16 new), covers injection attempts, NaN/Infinity, out-of-range limit/gridK, malformed country/h3/bucket
- [x] `pnpm check` — svelte-check + tsc clean
- [x] `pnpm build` — core + playground build clean
- [ ] Manual smoke test of reverse geocode in the playground against live S3

Closes #9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tighter validation for reverse-geocoding inputs (coordinates, limits, grid params) and stricter checks on tile IDs and bucket names to prevent unsafe interpolation and improve error handling.

* **Tests**
  * Added tests covering validation helpers, SQL generation for reverse lookups, and edge cases (invalid coords, buckets, limits, grid values).

* **Chores**
  * Expanded test coverage reporting outputs in CI configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->